### PR TITLE
Add global tree for normalization and remove mass less than 100 GeV

### DIFF
--- a/flashggAnalysisNtuplizer/interface/DataFormats.h
+++ b/flashggAnalysisNtuplizer/interface/DataFormats.h
@@ -4,6 +4,29 @@
 #include <TTree.h>
 #include <vector>
 
+
+class globalTreeFormat
+{
+    public:
+
+        float weight;
+
+        void Initialzation() {
+            weight = 1.;
+        }
+
+        void RegisterTree(TTree* tree) {
+            tree_ = tree;
+            tree_->Branch( "weight" , &weight , "weight/F" );
+        }
+
+        void TreeFill() { tree_->Fill(); }
+
+    private:
+        TTree* tree_;
+
+};
+
 class flashggAnalysisTreeFormatStd
 {
     public:
@@ -218,7 +241,7 @@ class flashggAnalysisTreeFormatStd
             NPu                                     = -999.;
             NVtx                                    = -999;
             passTrigger                             = false;
-            genweight                               = -999.; 
+            genweight                               = 1.;
             Rho                                     = -999.;
             PVz                                     = -999.;
             BSsigmaz                                = -999.;
@@ -243,8 +266,8 @@ class flashggAnalysisTreeFormatStd
             dipho_leadsieie                = -999.; 
             dipho_leadhoe                  = -999.; 
             dipho_leadIDMVA                = -999.;
-	    dipho_leadIsEB                 = false;
-	    dipho_leadIsEE                 = false;
+            dipho_leadIsEB                 = false;
+            dipho_leadIsEE                 = false;
             dipho_leadhasPixelSeed         = false;
             dipho_leadGenMatch             = false; 
             dipho_leadGenMatchType         = -999; 
@@ -259,15 +282,15 @@ class flashggAnalysisTreeFormatStd
             dipho_subleadsieie             = -999.; 
             dipho_subleadhoe               = -999.; 
             dipho_subleadIDMVA             = -999.;
-	    dipho_subleadIsEB              = false;
-	    dipho_subleadIsEE              = false;
+            dipho_subleadIsEB              = false;
+            dipho_subleadIsEE              = false;
             dipho_subleadhasPixelSeed      = false;
             dipho_subleadGenMatch          = false; 
             dipho_subleadGenMatchType      = -999;
             dipho_diphotonMVA              = -999.;
             dipho_SelectedVz               = -999.;
             dipho_GenVz                    = -999.;
-            dipho_centralWeight            = -999.; 
+            dipho_centralWeight            = 1.;
             dipho_MvaLinearSystUp          = -999.; 
             dipho_MvaLinearSystDown        = -999.; 
             dipho_LooseMvaSFUp             = -999.; 
@@ -341,9 +364,9 @@ class flashggAnalysisTreeFormatStd
             jets_QGL                                          .clear(); 
             jets_RMS                                          .clear(); 
             jets_puJetIdMVA                                   .clear();
-	    jets_passesPuJetIdLoose                           .clear();
-	    jets_passesPuJetIdMedium                          .clear();
-	    jets_passesPuJetIdTight                           .clear();
+            jets_passesPuJetIdLoose                           .clear();
+            jets_passesPuJetIdMedium                          .clear();
+            jets_passesPuJetIdTight                           .clear();
             jets_GenJetMatch                                  .clear();
             jets_pfCombinedInclusiveSecondaryVertexV2BJetTags .clear(); 
             jets_pfCombinedMVAV2BJetTags                      .clear(); 
@@ -351,12 +374,12 @@ class flashggAnalysisTreeFormatStd
             jets_pfDeepCSVJetTags_probbb                      .clear(); 
             jets_pfDeepCSVJetTags_probc                       .clear(); 
             jets_pfDeepCSVJetTags_probudsg                    .clear();
- 	    jets_pfDeepFlavourJetTags_probb                   .clear();
-	    jets_pfDeepFlavourJetTags_probbb                  .clear();
-	    jets_pfDeepFlavourJetTags_probc                   .clear();
-	    jets_pfDeepFlavourJetTags_probuds                 .clear();
-	    jets_pfDeepFlavourJetTags_probg                   .clear();
- 	    jets_pfDeepFlavourJetTags_problepb                .clear();
+            jets_pfDeepFlavourJetTags_probb                   .clear();
+            jets_pfDeepFlavourJetTags_probbb                  .clear();
+            jets_pfDeepFlavourJetTags_probc                   .clear();
+            jets_pfDeepFlavourJetTags_probuds                 .clear();
+            jets_pfDeepFlavourJetTags_probg                   .clear();
+            jets_pfDeepFlavourJetTags_problepb                .clear();
             jets_JECScale                                     .clear(); 
             jets_JERScale                                     .clear(); 
             jets_JECUnc                                       .clear(); 
@@ -453,8 +476,8 @@ class flashggAnalysisTreeFormatStd
             tree_->Branch( "DiPhoInfo.leadsieie"               , &dipho_leadsieie              , "DiPhoInfo.leadsieie/F"            );
             tree_->Branch( "DiPhoInfo.leadhoe"                 , &dipho_leadhoe                , "DiPhoInfo.leadhoe/F"              );
             tree_->Branch( "DiPhoInfo.leadIDMVA"               , &dipho_leadIDMVA              , "DiPhoInfo.leadIDMVA/F"            );
-	    tree_->Branch( "DiPhoInfo.leadIsEB"                , &dipho_leadIsEB               , "DiPhoInfo.leadIsEB/O"             );
-	    tree_->Branch( "DiPhoInfo.leadIsEE"                , &dipho_leadIsEE               , "DiPhoInfo.leadIsEE/O"             );
+            tree_->Branch( "DiPhoInfo.leadIsEB"                , &dipho_leadIsEB               , "DiPhoInfo.leadIsEB/O"             );
+            tree_->Branch( "DiPhoInfo.leadIsEE"                , &dipho_leadIsEE               , "DiPhoInfo.leadIsEE/O"             );
             tree_->Branch( "DiPhoInfo.leadhasPixelSeed"        , &dipho_leadhasPixelSeed       , "DiPhoInfo.leadhasPixelSeed/O"     );
             tree_->Branch( "DiPhoInfo.leadGenMatch"            , &dipho_leadGenMatch           , "DiPhoInfo.leadGenMatch/O"         );
             tree_->Branch( "DiPhoInfo.leadGenMatchType"        , &dipho_leadGenMatchType       , "DiPhoInfo.leadGenMatchType/I"     );
@@ -469,8 +492,8 @@ class flashggAnalysisTreeFormatStd
             tree_->Branch( "DiPhoInfo.subleadsieie"            , &dipho_subleadsieie           , "DiPhoInfo.subleadsieie/F"         );
             tree_->Branch( "DiPhoInfo.subleadhoe"              , &dipho_subleadhoe             , "DiPhoInfo.subleadhoe/F"           );
             tree_->Branch( "DiPhoInfo.subleadIDMVA"            , &dipho_subleadIDMVA           , "DiPhoInfo.subleadIDMVA/F"         );
-	    tree_->Branch( "DiPhoInfo.subleadIsEB"             , &dipho_subleadIsEB            , "DiPhoInfo.subleadIsEB/O"          );
-	    tree_->Branch( "DiPhoInfo.subleadIsEE"             , &dipho_subleadIsEE            , "DiPhoInfo.subleadIsEE/O"          );
+            tree_->Branch( "DiPhoInfo.subleadIsEB"             , &dipho_subleadIsEB            , "DiPhoInfo.subleadIsEB/O"          );
+            tree_->Branch( "DiPhoInfo.subleadIsEE"             , &dipho_subleadIsEE            , "DiPhoInfo.subleadIsEE/O"          );
             tree_->Branch( "DiPhoInfo.subleadhasPixelSeed"     , &dipho_subleadhasPixelSeed    , "DiPhoInfo.subleadhasPixelSeed/O"  );
             tree_->Branch( "DiPhoInfo.subleadGenMatch"         , &dipho_subleadGenMatch        , "DiPhoInfo.subleadGenMatch/O"      );
             tree_->Branch( "DiPhoInfo.subleadGenMatchType"     , &dipho_subleadGenMatchType    , "DiPhoInfo.subleadGenMatchType/I"  );
@@ -551,9 +574,9 @@ class flashggAnalysisTreeFormatStd
             tree_->Branch( "JetInfo.QGL"                                           , &jets_QGL                                          );
             tree_->Branch( "JetInfo.RMS"                                           , &jets_RMS                                          );
             tree_->Branch( "JetInfo.puJetIdMVA"                                    , &jets_puJetIdMVA                                   );
-	    tree_->Branch( "JetInfo.passesPuJetIdLoose"                            , &jets_passesPuJetIdLoose                           );
-	    tree_->Branch( "JetInfo.passesPuJetIdMedium"                           , &jets_passesPuJetIdMedium                          );
-	    tree_->Branch( "JetInfo.passesPuJetIdTight"                            , &jets_passesPuJetIdTight                           );
+            tree_->Branch( "JetInfo.passesPuJetIdLoose"                            , &jets_passesPuJetIdLoose                           );
+            tree_->Branch( "JetInfo.passesPuJetIdMedium"                           , &jets_passesPuJetIdMedium                          );
+            tree_->Branch( "JetInfo.passesPuJetIdTight"                            , &jets_passesPuJetIdTight                           );
             tree_->Branch( "JetInfo.GenJetMatch"                                   , &jets_GenJetMatch                                  );
             tree_->Branch( "JetInfo.pfCombinedInclusiveSecondaryVertexV2BJetTags"  , &jets_pfCombinedInclusiveSecondaryVertexV2BJetTags );
             tree_->Branch( "JetInfo.pfCombinedMVAV2BJetTags"                       , &jets_pfCombinedMVAV2BJetTags                      );
@@ -561,12 +584,12 @@ class flashggAnalysisTreeFormatStd
             tree_->Branch( "JetInfo.pfDeepCSVJetTags_probbb"                       , &jets_pfDeepCSVJetTags_probbb                      );
             tree_->Branch( "JetInfo.pfDeepCSVJetTags_probc"                        , &jets_pfDeepCSVJetTags_probc                       );
             tree_->Branch( "JetInfo.pfDeepCSVJetTags_probudsg"                     , &jets_pfDeepCSVJetTags_probudsg                    );
-	    tree_->Branch( "JetInfo.pfDeepFlavourJetTags_probb"                    , &jets_pfDeepFlavourJetTags_probb                   );
-	    tree_->Branch( "JetInfo.pfDeepFlavourJetTags_probbb"                   , &jets_pfDeepFlavourJetTags_probbb                  );
-	    tree_->Branch( "JetInfo.pfDeepFlavourJetTags_probc"                    , &jets_pfDeepFlavourJetTags_probc                   );
-	    tree_->Branch( "JetInfo.pfDeepFlavourJetTags_probuds"                  , &jets_pfDeepFlavourJetTags_probuds                 );
-	    tree_->Branch( "JetInfo.pfDeepFlavourJetTags_probg"                    , &jets_pfDeepFlavourJetTags_probg                   );
-	    tree_->Branch( "JetInfo.pfDeepFlavourJetTags_problepb"                 , &jets_pfDeepFlavourJetTags_problepb                );
+            tree_->Branch( "JetInfo.pfDeepFlavourJetTags_probb"                    , &jets_pfDeepFlavourJetTags_probb                   );
+            tree_->Branch( "JetInfo.pfDeepFlavourJetTags_probbb"                   , &jets_pfDeepFlavourJetTags_probbb                  );
+            tree_->Branch( "JetInfo.pfDeepFlavourJetTags_probc"                    , &jets_pfDeepFlavourJetTags_probc                   );
+            tree_->Branch( "JetInfo.pfDeepFlavourJetTags_probuds"                  , &jets_pfDeepFlavourJetTags_probuds                 );
+            tree_->Branch( "JetInfo.pfDeepFlavourJetTags_probg"                    , &jets_pfDeepFlavourJetTags_probg                   );
+            tree_->Branch( "JetInfo.pfDeepFlavourJetTags_problepb"                 , &jets_pfDeepFlavourJetTags_problepb                );
             tree_->Branch( "JetInfo.JECScale"                                      , &jets_JECScale                                     );
             tree_->Branch( "JetInfo.JERScale"                                      , &jets_JERScale                                     );
             tree_->Branch( "JetInfo.JECUnc"                                        , &jets_JECUnc                                       );
@@ -612,18 +635,18 @@ class flashggAnalysisTreeFormatStd
             tree_->Branch( "GenPartInfo.nMo"    , &GenParticles_nMo    );
             tree_->Branch( "GenPartInfo.nDa"    , &GenParticles_nDa    );
 	   
-	    tree_->Branch( "GenPartInfo.isHardProcess"                              , &GenParticles_isHardProcess    );
-	    tree_->Branch( "GenPartInfo.fromHardProcessFinalState"                  , &GenParticles_fromHardProcessFinalState    );
-	    tree_->Branch( "GenPartInfo.isPromptFinalState"                         , &GenParticles_isPromptFinalState    );
-	    tree_->Branch( "GenPartInfo.isDirectPromptTauDecayProductFinalState"    , &GenParticles_isDirectPromptTauDecayProductFinalState    );
-	   
-	    tree_->Branch( "GenPartInfo.MomPdgID"        , &GenParticles_MomPdgID    );
-	    tree_->Branch( "GenPartInfo.MomStatus"       , &GenParticles_MomStatus   );
-	    tree_->Branch( "GenPartInfo.MomPt"           , &GenParticles_MomPt       );
-	    tree_->Branch( "GenPartInfo.MomEta"          , &GenParticles_MomEta      );
-	    tree_->Branch( "GenPartInfo.MomPhi"          , &GenParticles_MomPhi      );
-	    tree_->Branch( "GenPartInfo.MomMass"         , &GenParticles_MomMass     );
-	   
+            tree_->Branch( "GenPartInfo.isHardProcess"                              , &GenParticles_isHardProcess    );
+            tree_->Branch( "GenPartInfo.fromHardProcessFinalState"                  , &GenParticles_fromHardProcessFinalState    );
+            tree_->Branch( "GenPartInfo.isPromptFinalState"                         , &GenParticles_isPromptFinalState    );
+            tree_->Branch( "GenPartInfo.isDirectPromptTauDecayProductFinalState"    , &GenParticles_isDirectPromptTauDecayProductFinalState    );
+
+            tree_->Branch( "GenPartInfo.MomPdgID"        , &GenParticles_MomPdgID    );
+            tree_->Branch( "GenPartInfo.MomStatus"       , &GenParticles_MomStatus   );
+            tree_->Branch( "GenPartInfo.MomPt"           , &GenParticles_MomPt       );
+            tree_->Branch( "GenPartInfo.MomEta"          , &GenParticles_MomEta      );
+            tree_->Branch( "GenPartInfo.MomPhi"          , &GenParticles_MomPhi      );
+            tree_->Branch( "GenPartInfo.MomMass"         , &GenParticles_MomMass     );
+
             tree_->Branch( "HTXSstage0cat"   , &HTXSstage0cat  , "HTXSstage0cat/I" );
             tree_->Branch( "HTXSstage1cat"   , &HTXSstage1cat  , "HTXSstage1cat/I" );
             tree_->Branch( "HTXSnjets"       , &HTXSnjets      , "HTXSnjets/I"     );

--- a/flashggAnalysisNtuplizer/plugins/flashggAnaTreeMerge.cc
+++ b/flashggAnalysisNtuplizer/plugins/flashggAnaTreeMerge.cc
@@ -65,9 +65,11 @@ flashggAnaTreeMerge::~flashggAnaTreeMerge()
 void
 flashggAnaTreeMerge::beginJob()
 {
+    //Global tree
     TTree* globaltree = fs_->make<TTree>( "global", "" );
     globaltreeformat.RegisterTree( globaltree );
 
+    //Standard tree
     int i_syst = 0;
     for ( auto& TreeMake : TreeMakeList_ ) {
         TTree* tree = fs_->make<TTree>( Form("flashggStdTree%s",DiphoSystNames_[i_syst].c_str()), "" );
@@ -84,13 +86,13 @@ flashggAnaTreeMerge::endJob()
 void
 flashggAnaTreeMerge::analyze( const edm::Event &iEvent, const edm::EventSetup &iSetup )
 {
-    //Global
+    //Global tree
     globaltreeformat.Initialzation();
     iEvent.getByToken( genEventInfoToken_ , genEventInfo );
     if(!iEvent.isRealData()) globaltreeformat.weight = genEventInfo->weight();
     globaltreeformat.TreeFill();
 
-
+    //Standard tree
     int itree = 0;
     for ( const auto& TreeMake : TreeMakeList_ ) {
         if (itree == 0) TreeMake->Analyze(iEvent, iSetup, false);

--- a/flashggAnalysisNtuplizer/src/flashggAnaTreeMakerWithSyst.cc
+++ b/flashggAnalysisNtuplizer/src/flashggAnaTreeMakerWithSyst.cc
@@ -57,21 +57,16 @@ flashggAnaTreeMakerWithSyst::RegisterTree( TTree* tree )
 const reco::GenParticle*
 flashggAnaTreeMakerWithSyst::getMother( const reco::GenParticle &part )
 {
-   const reco::GenParticle *mom = &part;
-   
-   while( mom->numberOfMothers() > 0 )
-     {	
-	for( unsigned int j=0;j<mom->numberOfMothers();++j )
-	  {	     
-	     mom = dynamic_cast<const reco::GenParticle*>(mom->mother(j));
-	     if( mom->pdgId() != part.pdgId() )
-	       {		  
-		  return mom;
-	       }	     
-	  }	          
-     }
-   
-   return mom;
+    const reco::GenParticle *mom = &part;
+
+    while( mom->numberOfMothers() > 0 ) {
+        for( unsigned int j=0;j<mom->numberOfMothers();++j ) {
+            mom = dynamic_cast<const reco::GenParticle*>(mom->mother(j));
+            if( mom->pdgId() != part.pdgId() ) return mom;
+        }
+    }
+
+    return mom;
 }
 
 void
@@ -161,10 +156,8 @@ flashggAnaTreeMakerWithSyst::Analyze( const edm::Event &iEvent, const edm::Event
             int NGenParticles = 0;
             const std::vector<edm::Ptr<reco::GenParticle> > genParticlesPtrs = genParticles->ptrs();
             for (const auto& it_gen : genParticles->ptrs()) {
-                if ( abs(it_gen->pdgId()) > 25) continue;
+                if ( abs(it_gen->pdgId()) > 25 ) continue;
                 if ( it_gen->status() > 30 ) continue;
-                //if ( it_gen->pdgId() == 22      && it_gen->status() == 1 && !(it_gen->pt() > 10 || it_gen->isPromptFinalState())) continue;
-                //if ( abs(it_gen->pdgId()) == 11 && it_gen->status() == 1 && !(it_gen->pt() > 3  || it_gen->isPromptFinalState())) continue;
 
                 dataformat.GenParticles_Pt     .emplace_back( it_gen->pt() );
                 dataformat.GenParticles_Eta    .emplace_back( it_gen->eta() );
@@ -175,19 +168,19 @@ flashggAnaTreeMakerWithSyst::Analyze( const edm::Event &iEvent, const edm::Event
                 dataformat.GenParticles_nMo    .emplace_back( it_gen->numberOfMothers() );
                 dataformat.GenParticles_nDa    .emplace_back( it_gen->numberOfDaughters() );
 	       
-	        dataformat.GenParticles_isHardProcess                              .emplace_back( it_gen->isHardProcess() );
-	        dataformat.GenParticles_fromHardProcessFinalState                  .emplace_back( it_gen->fromHardProcessFinalState() );
-	        dataformat.GenParticles_isPromptFinalState                         .emplace_back( it_gen->isPromptFinalState() );
-	        dataformat.GenParticles_isDirectPromptTauDecayProductFinalState    .emplace_back( it_gen->isDirectPromptTauDecayProductFinalState() );
-	       
-	        const reco::GenParticle* mom = getMother(*it_gen);
-	       
-	        dataformat.GenParticles_MomPdgID    .emplace_back( mom->pdgId() );
-	        dataformat.GenParticles_MomStatus   .emplace_back( mom->status() );
-	        dataformat.GenParticles_MomPt       .emplace_back( mom->pt() );
-	        dataformat.GenParticles_MomEta      .emplace_back( mom->eta() );
-	        dataformat.GenParticles_MomPhi      .emplace_back( mom->phi() );
-	        dataformat.GenParticles_MomMass     .emplace_back( mom->mass() );
+                dataformat.GenParticles_isHardProcess                              .emplace_back( it_gen->isHardProcess() );
+                dataformat.GenParticles_fromHardProcessFinalState                  .emplace_back( it_gen->fromHardProcessFinalState() );
+                dataformat.GenParticles_isPromptFinalState                         .emplace_back( it_gen->isPromptFinalState() );
+                dataformat.GenParticles_isDirectPromptTauDecayProductFinalState    .emplace_back( it_gen->isDirectPromptTauDecayProductFinalState() );
+
+                const reco::GenParticle* mom = getMother(*it_gen);
+
+                dataformat.GenParticles_MomPdgID    .emplace_back( mom->pdgId() );
+                dataformat.GenParticles_MomStatus   .emplace_back( mom->status() );
+                dataformat.GenParticles_MomPt       .emplace_back( mom->pt() );
+                dataformat.GenParticles_MomEta      .emplace_back( mom->eta() );
+                dataformat.GenParticles_MomPhi      .emplace_back( mom->phi() );
+                dataformat.GenParticles_MomMass     .emplace_back( mom->mass() );
 
                 NGenParticles++;
             }
@@ -393,13 +386,10 @@ flashggAnaTreeMakerWithSyst::Analyze( const edm::Event &iEvent, const edm::Event
             dataformat.jets_PtRaw                         .emplace_back( it_jet->correctedJet( "Uncorrected" ).pt() );
             dataformat.jets_QGL                           .emplace_back( it_jet->QGL() );
             dataformat.jets_RMS                           .emplace_back( it_jet->rms() );
-	    dataformat.jets_puJetIdMVA                    .emplace_back( it_jet->puJetIdMVA() );
-	    if (diphotonPtrs.size() > 0) 
-	      {		
-		 dataformat.jets_passesPuJetIdLoose       .emplace_back( it_jet->passesPuJetId( diphotonPtrs[0], PileupJetIdentifier::kLoose ) );
-		 dataformat.jets_passesPuJetIdMedium      .emplace_back( it_jet->passesPuJetId( diphotonPtrs[0], PileupJetIdentifier::kMedium ) );
-		 dataformat.jets_passesPuJetIdTight       .emplace_back( it_jet->passesPuJetId( diphotonPtrs[0], PileupJetIdentifier::kTight ) );
-	      }	   
+            dataformat.jets_puJetIdMVA                    .emplace_back( it_jet->puJetIdMVA() );
+            dataformat.jets_passesPuJetIdLoose            .emplace_back( it_jet->passesPuJetId( diphotonPtrs[0], PileupJetIdentifier::kLoose ) );
+            dataformat.jets_passesPuJetIdMedium           .emplace_back( it_jet->passesPuJetId( diphotonPtrs[0], PileupJetIdentifier::kMedium ) );
+            dataformat.jets_passesPuJetIdTight            .emplace_back( it_jet->passesPuJetId( diphotonPtrs[0], PileupJetIdentifier::kTight ) );
             dataformat.jets_GenJetMatch                   .emplace_back( it_jet->hasGenMatch() );
             dataformat.jets_pfCombinedInclusiveSecondaryVertexV2BJetTags        
                                                           .emplace_back( it_jet->bDiscriminator( "pfCombinedInclusiveSecondaryVertexV2BJetTags" ) );
@@ -410,11 +400,11 @@ flashggAnaTreeMakerWithSyst::Analyze( const edm::Event &iEvent, const edm::Event
             dataformat.jets_pfDeepCSVJetTags_probudsg     .emplace_back( it_jet->bDiscriminator( "pfDeepCSVJetTags:probudsg" ) );
 
             dataformat.jets_pfDeepFlavourJetTags_probb        .emplace_back( it_jet->bDiscriminator( "pfDeepFlavourJetTags:probb" ) );
-	    dataformat.jets_pfDeepFlavourJetTags_probbb       .emplace_back( it_jet->bDiscriminator( "pfDeepFlavourJetTags:probbb" ) );
-	    dataformat.jets_pfDeepFlavourJetTags_probc        .emplace_back( it_jet->bDiscriminator( "pfDeepFlavourJetTags:probc" ) );
-	    dataformat.jets_pfDeepFlavourJetTags_probuds      .emplace_back( it_jet->bDiscriminator( "pfDeepFlavourJetTags:probuds" ) );
- 	    dataformat.jets_pfDeepFlavourJetTags_probg        .emplace_back( it_jet->bDiscriminator( "pfDeepFlavourJetTags:probg" ) );
-	    dataformat.jets_pfDeepFlavourJetTags_problepb     .emplace_back( it_jet->bDiscriminator( "pfDeepFlavourJetTags:problepb" ) );
+            dataformat.jets_pfDeepFlavourJetTags_probbb       .emplace_back( it_jet->bDiscriminator( "pfDeepFlavourJetTags:probbb" ) );
+            dataformat.jets_pfDeepFlavourJetTags_probc        .emplace_back( it_jet->bDiscriminator( "pfDeepFlavourJetTags:probc" ) );
+            dataformat.jets_pfDeepFlavourJetTags_probuds      .emplace_back( it_jet->bDiscriminator( "pfDeepFlavourJetTags:probuds" ) );
+            dataformat.jets_pfDeepFlavourJetTags_probg        .emplace_back( it_jet->bDiscriminator( "pfDeepFlavourJetTags:probg" ) );
+            dataformat.jets_pfDeepFlavourJetTags_problepb     .emplace_back( it_jet->bDiscriminator( "pfDeepFlavourJetTags:problepb" ) );
 	   
             auto jer = flashggAnalysisNtuplizer::JERUncertainty( *it_jet, *rho, iSetup );
             dataformat.jets_JECScale                      .emplace_back( it_jet->pt() / it_jet->correctedJet( "Uncorrected" ).pt() );
@@ -478,11 +468,11 @@ flashggAnaTreeMakerWithSyst::Analyze( const edm::Event &iEvent, const edm::Event
             dataformat.met_CorrPhiShiftPhoEnUp          = theMet->shiftedPhi ( pat::MET::PhotonEnUp        );
             dataformat.met_CorrPhiShiftPhoEnDown        = theMet->shiftedPhi ( pat::MET::PhotonEnDown      );
         }
-    }
-    //Only store the first diphoton candidate which passes diphoton preselection
-    //If events with on diphoton candidate passing the diphoton preselection, the mass will be set -999.
-    dataformat.TreeFill();
+    
+        //Only store the first diphoton candidate which passes diphoton preselection with mass > 100 GeV
+        if(diphoPtr->mass() > 100.) dataformat.TreeFill();
 
+    }//diphoton candidate > 0
 }
 
 // Local Variables:


### PR DESCRIPTION
@kskovpen @lceard
- Storing those no diphoton candidate events that is set -999 seems to result in too big file size and "junk" events, especially background MC samples, which has large events but few diphoton candidate. Consider to keep gen weight of all events for normalization, I propose to create an additional tree (in the same root file) called "global" to store only gen weight for all events and our standard tree only store events with the first diphoton candidate which passes diphoton preselection and mass > 100 GeV. I think it not only reduces file size and "junk" events but also keep the normalization information. Also let user not spend much time to remove those "junk" events (which is set -999).

- Modify genweight and dipho_centralWeight initialization value to 1 for consistency to data and MC. This might be more suitable for user.

Are these changes a good idea?
